### PR TITLE
Advance auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@
 
 A Swift library that interacts with [Gotenberg](https://gotenberg.dev/)'s different modules to convert a variety of document formats to PDF files.
 
+# Table of Contents
+
+1. [Getting Started](#getting-started)
+   - [Installation](#snippets)
+   - [Prerequisites](#prerequisites)
+   - [Configuration](#configuration)
+2. [Authentication](#authentication)
+   - [Basic Authentication](#basic-authentication)
+   - [Advanced Authentication](#advanced-authentication)
+3. [Core Features](#core-features)
+   - [Chromium](#chromium)
+     - [URL](#url)
+     - [HTML](#html)
+     - [Markdown](#markdown)
+     - [Screenshot](#screenshot)
+   - [LibreOffice](#libreoffice)
+   - [PDF Engines](#pdf-engines)
+     - [Format Conversion](#format-conversion)
+     - [Merging](#merging)
+     - [Metadata Management](#metadata-management)
+     - [File Generation](#file-generation)
+   - [PDF Splitting](#pdf-splitting)
+4. [Usage Example](#snippet)
+
+## Getting Started
+
 ## Snippets
 To incorporate `gotenberg-kit` into your project, follow the snippets below for SPM dependencies.
 
@@ -31,7 +57,7 @@ Once the docker Daemon is up and running, you can start a default Docker contain
 docker run --rm -p 7100:7100 gotenberg/gotenberg:8 gotenberg --api-port=7100
 ```
 
-## Get Started
+## Configuration
 
 Create an instance of `Gotenberg` class and pass your `Gotenberg` `endpoint` url as a constructor parameter.
 
@@ -40,6 +66,59 @@ let client = GotenbergClient(
     baseURL: URL(string: ProcessInfo.processInfo.environment["GOTENBERG_URL"] ?? "http://localhost:7100")!
 )
 ```
+
+## Authentication
+
+### Basic Authentication
+
+Gotenberg introduces basic authentication support starting from version [8.4.0](https://github.com/gotenberg/gotenberg/releases/tag/v8.4.0). Suppose you are running a Docker container using the command below:
+
+```bash
+docker run --rm -p 3000:3000 \
+-e GOTENBERG_API_BASIC_AUTH_USERNAME=gotenberg \
+-e GOTENBERG_API_BASIC_AUTH_PASSWORD=password \
+gotenberg/gotenberg:8.4.0 gotenberg --api-enable-basic-auth
+
+```
+
+To integrate this setup with Chromiumly, you need to update your client instance as outlined below:
+
+
+```Swift
+let client = GotenbergClient(
+    baseURL: URL(
+        string: ProcessInfo.processInfo.environment["GOTENBERG_URL"] ?? "http://localhost:7100"
+    )!,
+    username: "gotenberg",
+    password: "password"
+)
+```
+
+### Advanced Authentication
+
+To implement advanced authentication or add custom HTTP headers to your requests, you can use the `customHttpHeaders` option within the `configure` method. This allows you to pass additional headers, such as authentication tokens or custom metadata, with each API call.
+
+For example, you can include a Bearer token for authentication along with a custom header as follows:
+
+```swift
+let token = try await generateToken();
+
+let client = GotenbergClient(
+    baseURL: URL(
+        string: ProcessInfo.processInfo.environment["GOTENBERG_URL"] ?? "http://localhost:7100"
+    )!,
+    customHttpHeaders: [
+        "Authorization": "Bearer \(token)",
+        "X-Custom-Header": "value",
+    ]
+)
+
+```
+
+## Core Features
+
+GotenbergKit exposes different funcs that serve as wrappers to
+Gotenberg's [routes](https://gotenberg.dev/docs/routes)
 
 ### Chromium
 
@@ -71,5 +150,11 @@ let response = try await client.convertHtml(
 #### Markdown
 
 This route accepts an `index.html` file plus markdown files. Check [Gotenberg docs](https://gotenberg.dev/docs/routes#markdown-files-into-pdf-route) for details.
+
+#### Screenshot
+
+### LibreOffice
+
+### PDF Engines
 
 # under construction

--- a/Sources/GotenbergKit/Common/PageProperties.swift
+++ b/Sources/GotenbergKit/Common/PageProperties.swift
@@ -65,7 +65,7 @@ public class PageProperties {
     public private(set) var emulatedMediaType: EmulatedMediaType? = nil
     /// Exported document metadata
     public private(set) var metadata: Metadata? = nil
-    /// Should flatten document
+    /// When set to true, flattens the split PDF files, making form fields and annotations uneditable
     public private(set) var flatten: Bool = false
     /// Should merge documents
     /// Setting false will return a zip with all supported files coverted to PDF

--- a/Sources/GotenbergKit/GotenbergClient.swift
+++ b/Sources/GotenbergKit/GotenbergClient.swift
@@ -21,6 +21,7 @@ public struct GotenbergClient: Sendable {
     internal let username: String?
     internal let password: String?
     internal let userAgent: String
+    internal let customHttpHeaders: [String: String]
 
     public typealias GotenbergResponse = HTTPClientResponse
 
@@ -30,13 +31,14 @@ public struct GotenbergClient: Sendable {
     ///   - logger: Optional logger
     ///   - username: Optional username for the Gotenberg server
     ///   - password: Optional password for the Gotenberg server
+    ///   - userAgent: Optional userAgent for all HTTP calls to the Gotenberg server
     ///   - httpClient: HTTClient
     public init(
         baseURL: URL,
         logger: Logger = Logger(label: "com.gotenberg.swift"),
         username: String? = nil,
         password: String? = nil,
-        userAgent: String = "Gotenberg Swift SDK/0.1",
+        userAgent: String = "Gotenberg Swift SDK/1.0",
         httpClient: HTTPClient = HTTPClient.shared
     ) {
         self.baseURL = baseURL
@@ -44,6 +46,34 @@ public struct GotenbergClient: Sendable {
         self.username = username
         self.password = password
         self.userAgent = userAgent
+        self.httpClient = httpClient
+        self.customHttpHeaders = [:]
+    }
+
+    /// Initialize the Gotenberg client
+    /// - Parameters:
+    ///   - baseURL: Base URL of the Gotenberg service (e.g., "http://localhost:3000")
+    ///   - logger: Optional logger
+    ///   - username: Optional username for the Gotenberg server
+    ///   - password: Optional password for the Gotenberg server
+    ///   - userAgent: Optional userAgent for all HTTP calls to the Gotenberg server
+    ///   - customHttpHeaders: For advanced authentication or add custom HTTP headers to requests to the Gotenberg server
+    ///   - httpClient: HTTClient
+    public init(
+        baseURL: URL,
+        logger: Logger = Logger(label: "com.gotenberg.swift"),
+        username: String? = nil,
+        password: String? = nil,
+        userAgent: String = "Gotenberg Swift SDK/1.0",
+        customHttpHeaders: [String: String],
+        httpClient: HTTPClient = HTTPClient.shared
+    ) {
+        self.baseURL = baseURL
+        self.logger = logger
+        self.username = username
+        self.password = password
+        self.userAgent = userAgent
+        self.customHttpHeaders = customHttpHeaders
         self.httpClient = httpClient
     }
 
@@ -104,6 +134,11 @@ public struct GotenbergClient: Sendable {
         // Add additional headers
         for (name, value) in headers {
             request.headers.add(name: name, value: value)
+        }
+
+        // custom http headers
+        for (key, value) in customHttpHeaders {
+            request.headers.add(name: key, value: value)
         }
 
         // Set the request body


### PR DESCRIPTION
* It's now possible to put Gotenberg behind a proxy that supports authentication to be able to authenticate and call the API (This is particularly useful for those who host Gotenberg on GCP cloud run)
* Starting to document the library