### PR TITLE
Do not call shutdown for HTTPClient.shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,5 +383,5 @@ let response = try await client.flattenPDF(
 
 #### File Generation
 
-It is just a complementary function that takes the `GotenbergResponse` returned by any functions beside readPDFMetadata, and a
+`client.writeToFile` is just a complementary function that takes the `GotenbergResponse` returned by any functions beside readPDFMetadata, and a
 chosen `filepath` with name to generate a PDF file or zip file. Note that note that this function will not create sub directories if not already exist.

--- a/Sources/GotenbergKit/GotenbergClient.swift
+++ b/Sources/GotenbergKit/GotenbergClient.swift
@@ -89,10 +89,6 @@ public struct GotenbergClient: Sendable {
         headers: [String: String]
     ) async throws -> GotenbergResponse {
 
-        defer {
-            _ = httpClient.shutdown()
-        }
-
         // Create multipart form data
         let boundary = "------------------------\(UUID().uuidString)"
         var body = Data()


### PR DESCRIPTION
Need to revisit this again incase a user passed in their own HTTPClient, we will have to call shutdown in that instance