### PR TITLE
Deadline and minimum async HTTP client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
     ],
     targets: [

--- a/Sources/GotenbergKit/GotenbergClient.swift
+++ b/Sources/GotenbergKit/GotenbergClient.swift
@@ -164,10 +164,10 @@ public struct GotenbergClient: Sendable {
         logger.debug("Sending request to Gotenberg: \(endpoint.absoluteString)")
 
         // Execute the request
-        let timeout = TimeInterval(headers["Gotenberg-Wait-Timeout"] ?? "30") ?? 30
+        let timeout = Int64(headers["Gotenberg-Wait-Timeout"] ?? "60") ?? 60
         let response = try await httpClient.execute(
             request,
-            timeout: .seconds(Int64(timeout + 2.5))
+            deadline: .now() + .seconds(timeout)
         )
 
         switch response.status {


### PR DESCRIPTION
* Use deadline instead of timeout
* Require minimum Async HTTP Client version 1.26.0