### PR TITLE
Add meta endpoints (health, version), some other improvements

### DIFF
--- a/Sources/GotenbergKit/Chromium/ChromiumOptions.swift
+++ b/Sources/GotenbergKit/Chromium/ChromiumOptions.swift
@@ -235,9 +235,7 @@ public struct ChromiumOptions: Sendable {
         if let extraHttpHeaders = extraHttpHeaders, !extraHttpHeaders.isEmpty {
             do {
                 let headersData = try JSONEncoder().encode(extraHttpHeaders)
-                if let headersString = String(data: headersData, encoding: .utf8) {
-                    values["extraHttpHeaders"] = headersString
-                }
+                values["extraHttpHeaders"] = String(decoding: headersData, as: UTF8.self)
             } catch {
                 logger.error(
                     "Failed to serialize extra HTTP headers",
@@ -252,35 +250,27 @@ public struct ChromiumOptions: Sendable {
             values["pdfa"] = pdfFormat.rawValue
         }
 
-        if let cookies = cookies {
-            if !cookies.isEmpty {
-                do {
-                    let cookies = try JSONEncoder().encode(cookies)
-                    if let cookies = String(data: cookies, encoding: .utf8) {
-                        values["cookies"] = cookies
-                    }
-                } catch {
-                    logger.error(
-                        "Failed to serialize extra Cookies",
-                        metadata: [
-                            "error": .string(error.localizedDescription)
-                        ]
-                    )
-                }
+        if let cookies = cookies, !cookies.isEmpty {
+            do {
+                let cookies = try JSONEncoder().encode(cookies)
+                values["cookies"] = String(decoding: cookies, as: UTF8.self)
+            } catch {
+                logger.error(
+                    "Failed to serialize extra Cookies",
+                    metadata: [
+                        "error": .string(error.localizedDescription)
+                    ]
+                )
             }
         }
 
         if let metadata = metadata {
             do {
-
                 let encoder = JSONEncoder()
-
                 encoder.dateEncodingStrategy = .formatted(Metadata.dateFormatter())
 
                 let data = try encoder.encode(metadata)
-                if let metadataString = String(data: data, encoding: .utf8) {
-                    values["metadata"] = metadataString
-                }
+                values["metadata"] = String(decoding: data, as: UTF8.self)
             } catch {
                 logger.error(
                     "Failed to serialize metadata",

--- a/Sources/GotenbergKit/Chromium/GotenbergClient+Chromium+Screenshots.swift
+++ b/Sources/GotenbergKit/Chromium/GotenbergClient+Chromium+Screenshots.swift
@@ -50,14 +50,12 @@ extension GotenbergClient {
             )
         }
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/chromium/screenshot/html",
             files: files,
             values: options.formValues,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -96,14 +94,12 @@ extension GotenbergClient {
             ),
         ]
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/chromium/screenshot/markdown",
             files: files,
             values: options.formValues,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -122,12 +118,8 @@ extension GotenbergClient {
         waitTimeout: TimeInterval = 120,
         clientHTTPHeaders: [String: String] = [:]
     ) async throws -> GotenbergResponse {
-        guard let htmlData = html.data(using: .utf8) else {
-            throw GotenbergError.invalidInput(message: "Failed to encode HTML string as UTF-8")
-        }
-
         return try await capture(
-            html: htmlData,
+            html: Data(html.utf8),
             assets: assets,
             options: options,
             waitTimeout: waitTimeout,
@@ -155,14 +147,12 @@ extension GotenbergClient {
         var values = options.formValues
         values["url"] = url.absoluteString
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/chromium/screenshot/url",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 

--- a/Sources/GotenbergKit/Chromium/GotenbergClient+Chromium+Screenshots.swift
+++ b/Sources/GotenbergKit/Chromium/GotenbergClient+Chromium+Screenshots.swift
@@ -118,7 +118,7 @@ extension GotenbergClient {
         waitTimeout: TimeInterval = 120,
         clientHTTPHeaders: [String: String] = [:]
     ) async throws -> GotenbergResponse {
-        return try await capture(
+        try await capture(
             html: Data(html.utf8),
             assets: assets,
             options: options,

--- a/Sources/GotenbergKit/Chromium/ScreenshotOptions.swift
+++ b/Sources/GotenbergKit/Chromium/ScreenshotOptions.swift
@@ -136,10 +136,8 @@ public struct ScreenshotOptions: Sendable {
             values["failOnResourceHttpStatusCodes"] = "[\(failOnResourceHttpStatusCodes.map(String.init).joined(separator: ","))]"
         }
 
-        if let quality = quality {
-            if format == .jpeg {
-                values["quality"] = "\(quality)"
-            }
+        if let quality = quality, format == .jpeg {
+            values["quality"] = "\(quality)"
         }
 
         if let waitDelay = waitDelay {
@@ -157,9 +155,7 @@ public struct ScreenshotOptions: Sendable {
         if let extraHttpHeaders = extraHttpHeaders, !extraHttpHeaders.isEmpty {
             do {
                 let headersData = try JSONEncoder().encode(extraHttpHeaders)
-                if let headersString = String(data: headersData, encoding: .utf8) {
-                    values["extraHttpHeaders"] = headersString
-                }
+                values["extraHttpHeaders"] = String(decoding: headersData, as: UTF8.self)
             } catch {
                 logger.error(
                     "Failed to serialize extra HTTP headers",
@@ -173,9 +169,7 @@ public struct ScreenshotOptions: Sendable {
         if let cookies = cookies {
             do {
                 let cookies = try JSONEncoder().encode(cookies)
-                if let headersString = String(data: cookies, encoding: .utf8) {
-                    values["cookies"] = headersString
-                }
+                values["cookies"] = String(decoding: cookies, as: UTF8.self)
             } catch {
                 logger.error(
                     "Failed to serialize cookies",

--- a/Sources/GotenbergKit/Common/GotenbergHealth.swift
+++ b/Sources/GotenbergKit/Common/GotenbergHealth.swift
@@ -1,0 +1,47 @@
+//
+//  GotenbergHealth.swift
+//  gotenberg-kit
+//
+//  Created by Florian Friedrich on 10.06.25.
+//
+
+import struct Foundation.Date
+
+/// Contains heatlh information of a Gotenberg instance.
+public struct GotenbergHealth: Sendable, Equatable, Codable {
+    /// Describes possible health status values.
+    public enum Status: String, Sendable, Hashable, Codable {
+        /// The system status is unknown
+        case unknown
+        /// The system is up and running
+        case up
+        /// The system is down
+        case down
+    }
+
+    /// Represents the status of a Gotenberg module.
+    public struct ModuleStatus: Sendable, Equatable, Codable {
+        /// The current status of the module.
+        public let status: Status
+        /// The timestamp of the last check of the module.
+        public let timestamp: Date
+    }
+
+    /// Contains the health details for each module of a Gotenberg instance.
+    public struct ModuleDetails: Sendable, Equatable, Codable {
+        private enum CodingKeys: String, CodingKey {
+            case chromium
+            case libreOffice = "libreoffice"
+        }
+
+        /// The status of the Chromium module.
+        public let chromium: ModuleStatus?
+        /// The status of the LibreOffice module.
+        public let libreOffice: ModuleStatus?
+    }
+
+    /// The overall system status.
+    public let status: Status
+    /// The module details of the system.
+    public let details: ModuleDetails?
+}

--- a/Sources/GotenbergKit/Common/Metadata.swift
+++ b/Sources/GotenbergKit/Common/Metadata.swift
@@ -6,6 +6,7 @@
 //
 
 import Logging
+
 import struct Foundation.Date
 import class Foundation.DateFormatter
 import class Foundation.JSONEncoder

--- a/Sources/GotenbergKit/Common/Metadata.swift
+++ b/Sources/GotenbergKit/Common/Metadata.swift
@@ -4,8 +4,11 @@
 //
 //  Created by Stevenson Michel on 4/11/25.
 //
+
+import Logging
 import struct Foundation.Date
 import class Foundation.DateFormatter
+import class Foundation.JSONEncoder
 import struct Foundation.Locale
 import struct Foundation.TimeZone
 
@@ -93,5 +96,23 @@ public struct Metadata: Codable, Sendable {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
+    }
+
+    package static func serializeAsJSON(_ metadata: [String: String], logger: Logger) throws -> String {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .formatted(dateFormatter())
+
+            let data = try encoder.encode(metadata)
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            logger.error(
+                "Error serializing metadata",
+                metadata: [
+                    "error": .string(error.localizedDescription)
+                ]
+            )
+            throw GotenbergError.invalidInput(message: "Error serializing metadata")
+        }
     }
 }

--- a/Sources/GotenbergKit/GotenbergClient+Health.swift
+++ b/Sources/GotenbergKit/GotenbergClient+Health.swift
@@ -1,0 +1,40 @@
+//
+//  GotenbergClient+Health.swift
+//  gotenberg-kit
+//
+//  Created by Florian Friedrich on 10.06.25.
+//
+
+import class Foundation.ISO8601DateFormatter
+import class Foundation.JSONDecoder
+import typealias Foundation.TimeInterval
+
+extension GotenbergClient {
+    /// Get the current Gotenberg health status.
+    /// - Parameters:
+    ///   - waitTimeout: Timeout in seconds for the Gotenberg server
+    ///   - clientHTTPHeaders: Custom headers for GotenbergKit
+    /// - Returns: The health of the Gotenberg instance this client connects to.
+    public func health(
+        waitTimeout: TimeInterval = 30,
+        clientHTTPHeaders: [String: String] = [:]
+    ) async throws -> GotenbergHealth {
+        let timeoutSeconds = Int64(waitTimeout)
+        let request = makeRequest(method: .GET, route: "health", timeoutSeconds: timeoutSeconds, headers: clientHTTPHeaders)
+        let response = try await sendRequestWithRetry(request, timeoutSeconds: timeoutSeconds)
+        // Health response is a rather simple JSON. 8kB are more than enough space.
+        let responseData = try await response.body.collect(upTo: 1024 * 8)
+        let decoder = JSONDecoder()
+        // The standard ISO8601 format does not include fractional seconds, but the Gotenberg response does.
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            guard let date = formatter.date(from: dateString)
+            else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid ISO8601 date: '\(dateString)'") }
+            return date
+        }
+        return try decoder.decode(GotenbergHealth.self, from: responseData)
+    }
+}

--- a/Sources/GotenbergKit/GotenbergClient+Version.swift
+++ b/Sources/GotenbergKit/GotenbergClient+Version.swift
@@ -1,0 +1,27 @@
+//
+//  GotenbergClient+Version.swift
+//  gotenberg-kit
+//
+//  Created by Florian Friedrich on 10.06.25.
+//
+
+import typealias Foundation.TimeInterval
+
+extension GotenbergClient {
+    /// Get the current Gotenberg version.
+    /// - Parameters:
+    ///   - waitTimeout: Timeout in seconds for the Gotenberg server
+    ///   - clientHTTPHeaders: Custom headers for GotenbergKit
+    /// - Returns: The version of the Gotenberg instance this client connects to.
+    public func version(
+        waitTimeout: TimeInterval = 10,
+        clientHTTPHeaders: [String: String] = [:]
+    ) async throws -> String {
+        let timeoutSeconds = Int64(waitTimeout)
+        let request = makeRequest(method: .GET, route: "version", timeoutSeconds: timeoutSeconds, headers: clientHTTPHeaders)
+        let response = try await sendRequestWithRetry(request, timeoutSeconds: timeoutSeconds)
+        // The version response is a simple string. 1kB is more than enough.
+        let responseData = try await response.body.collect(upTo: 1024)
+        return String(buffer: responseData)
+    }
+}

--- a/Sources/GotenbergKit/GotenbergClient.swift
+++ b/Sources/GotenbergKit/GotenbergClient.swift
@@ -4,6 +4,7 @@
 import AsyncHTTPClient
 import Logging
 import NIO
+import NIOHTTP1
 import NIOFoundationCompat
 
 import struct Foundation.Data
@@ -87,14 +88,16 @@ public struct GotenbergClient: Sendable {
     ///   - files: Array of files to include in the request
     ///   - values: Dictionary of form values to include
     ///   - headers: Additional HTTP headers to include
+    ///   - timeoutSeconds: The number of seconds before the request times out
     /// - Returns: GotenbergResponse
     internal func sendFormRequest(
         route: String,
         files: [FormFile],
         values: [String: String],
         headers: [String: String],
+        timeoutSeconds: Int64
     ) async throws -> GotenbergResponse {
-        try await makeRequest(route: route, files: files, values: values, headers: headers)
+        try await sendPOSTRequest(route: route, files: files, values: values, headers: headers, timeoutSeconds: timeoutSeconds)
     }
 
     /// Sends a form request to Gotenberg with files and values
@@ -103,14 +106,14 @@ public struct GotenbergClient: Sendable {
     ///   - files: Array of files to include in the request
     ///   - values: Dictionary of form values to include
     ///   - headers: Additional HTTP headers to include
-    ///   - currentRetryCount: Current retry count
+    ///   - timeoutSeconds: The number of seconds before the request times out
     /// - Returns: GotenbergResponse
-    private func makeRequest(
+    private func sendPOSTRequest(
         route: String,
         files: [FormFile],
         values: [String: String],
         headers: [String: String],
-        currentRetryCount: Int = 0
+        timeoutSeconds: Int64
     ) async throws -> GotenbergResponse {
         // Create multipart form data
         let boundary = "------------------------\(UUID().uuidString)"
@@ -118,30 +121,46 @@ public struct GotenbergClient: Sendable {
 
         // Add form values
         for (name, value) in values {
-            body.append("--\(boundary)\r\n".data(using: .utf8)!)
-            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
-            body.append("\(value)\r\n".data(using: .utf8)!)
+            body.append(contentsOf: "--\(boundary)\r\n".utf8)
+            body.append(contentsOf: "Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".utf8)
+            body.append(contentsOf: "\(value)\r\n".utf8)
         }
 
         // Add files
         for file in files {
-            body.append("--\(boundary)\r\n".data(using: .utf8)!)
-            body.append("Content-Disposition: form-data; name=\"\(file.name)\"; filename=\"\(file.filename)\"\r\n".data(using: .utf8)!)
-            body.append("Content-Type: \(file.contentType)\r\n\r\n".data(using: .utf8)!)
+            body.append(contentsOf: "--\(boundary)\r\n".utf8)
+            body.append(contentsOf: "Content-Disposition: form-data; name=\"\(file.name)\"; filename=\"\(file.filename)\"\r\n".utf8)
+            body.append(contentsOf: "Content-Type: \(file.contentType)\r\n\r\n".utf8)
             body.append(file.data)
-            body.append("\r\n".data(using: .utf8)!)
+            body.append(contentsOf: "\r\n".utf8)
         }
 
         // Add final boundary
-        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        body.append(contentsOf: "--\(boundary)--\r\n".utf8)
 
+        // Create the request
+        var request = makeRequest(method: .POST, route: route, timeoutSeconds: timeoutSeconds, headers: headers)
+        request.headers.add(name: "Content-Type", value: "multipart/form-data; boundary=\(boundary)")
+        request.headers.add(name: "Content-Length", value: "\(body.count)")
+        request.body = .bytes(ByteBuffer(data: body))
+
+        return try await sendRequestWithRetry(request, timeoutSeconds: timeoutSeconds)
+    }
+
+    /// Creates a HTTP client request for sending to Gotenberg.
+    /// - Parameters:
+    ///   - method: The method to use
+    ///   - route: The API route to send the request to
+    ///   - timeoutSeconds: The number of seconds before the request times out
+    ///   - headers: Additional HTTP headers to include
+    /// - Returns: HTTPClientRequest
+    internal func makeRequest(method: HTTPMethod, route: String, timeoutSeconds: Int64, headers: [String: String]) -> HTTPClientRequest {
         // Create the request
         let endpoint = baseURL.appendingPathComponent(route)
         var request = HTTPClientRequest(url: endpoint.absoluteString)
-        request.method = .POST
-        request.headers.add(name: "Content-Type", value: "multipart/form-data; boundary=\(boundary)")
-        request.headers.add(name: "Content-Length", value: "\(body.count)")
+        request.method = method
         request.headers.add(name: "User-Agent", value: userAgent)
+        request.headers.add(name: "Gotenberg-Wait-Timeout", value: String(timeoutSeconds))
 
         if let username = username, let password = password {
             logger.debug("Using basic auth for Gotenberg API")
@@ -158,20 +177,30 @@ public struct GotenbergClient: Sendable {
             request.headers.add(name: key, value: value)
         }
 
-        // Set the request body
-        request.body = .bytes(ByteBuffer(data: body))
+        return request
+    }
 
-        logger.debug("Sending request to Gotenberg: \(endpoint.absoluteString)")
+    /// Sends an HTTP client request to Gotenberg. The request will be retried depending on the response status code.
+    /// - Parameters:
+    ///   - request: The API route to send the request to
+    ///   - timeoutSeconds: The number of seconds before the request times out
+    ///   - currentRetryCount: Current retry count
+    /// - Returns: GotenbergResponse
+    internal func sendRequestWithRetry(
+        _ request: HTTPClientRequest,
+        timeoutSeconds: Int64,
+        currentRetryCount: Int = 0
+    ) async throws -> GotenbergResponse {
+        logger.debug("Sending request to Gotenberg: \(request.url)")
 
         // Execute the request
-        let timeout = Int64(headers["Gotenberg-Wait-Timeout"] ?? "60") ?? 60
-        let response = try await httpClient.execute(
-            request,
-            deadline: .now() + .seconds(timeout)
-        )
+        let response = try await httpClient.execute(request, deadline: .now() + .seconds(timeoutSeconds))
 
+        // Handle response based on status
         switch response.status {
-        case .gatewayTimeout, .tooManyRequests, .serviceUnavailable, .requestTimeout, .internalServerError:
+        case .ok, .noContent:
+            return response
+        case .gatewayTimeout, .tooManyRequests, .serviceUnavailable, .requestTimeout, .internalServerError: // Retry-able status
             let retryCount = currentRetryCount + 1
             if retryCount < maxRetries {
                 let delayTime = min(exp2(Double(retryCount)), 30)
@@ -179,64 +208,32 @@ public struct GotenbergClient: Sendable {
                 let delay = delayTime * (1 + jitter)
                 logger.debug("Gotenberg API returned \(response.status), retrying in \(delay) seconds with attempt count... \(retryCount)")
                 try await Task.sleep(for: .seconds(delay))
-                return try await makeRequest(
-                    route: route,
-                    files: files,
-                    values: values,
-                    headers: headers,
-                    currentRetryCount: retryCount
-                )
+                return try await sendRequestWithRetry(request, timeoutSeconds: timeoutSeconds, currentRetryCount: retryCount)
             }
 
             throw GotenbergError.apiError(statusCode: response.status.code, message: "Exhausted retry attempts")
-        case .ok:
-            return response
-        default: break
+        default: // Any non-success, non-retryable status
+            let errorData = try await response.body.collect(upTo: 1024 * 1024 * 8) // 8 MB of error response gotta be enough...
+            let errorMessage = String(buffer: errorData)
+            logger.error(
+                "Gotenberg API error with status",
+                metadata: [
+                    "statusCode": "\(response.status.code)",
+                    "message": .string(errorMessage),
+                ]
+            )
+            throw GotenbergError.apiError(statusCode: response.status.code, message: errorMessage)
         }
-
-        // Validate the response status
-        guard response.status == .ok else {
-            var errorData = Data()
-            for try await buffer in response.body {
-                errorData.append(Data(buffer.readableBytesView))
-            }
-
-            if let errorMessage = String(data: errorData, encoding: .utf8) {
-                logger.error(
-                    "Gotenberg API error with status",
-                    metadata: [
-                        "statusCode": "\(response.status.code)",
-                        "message": .string(errorMessage),
-                    ]
-                )
-                throw GotenbergError.apiError(statusCode: response.status.code, message: errorMessage)
-            } else {
-                logger.error(
-                    "Gotenberg API error",
-                    metadata: [
-                        "statusCode": "\(response.status.code)",
-                        "message": "Unknown error",
-                    ]
-                )
-                throw GotenbergError.apiError(statusCode: response.status.code, message: "Unknown error")
-            }
-        }
-
-        return response
     }
 
-    /// Conver an HTTPClientResponse into data
+    /// Convert an HTTPClientResponse into data
     /// - Parameters:
     ///   - response: The API response
     /// - Returns: Response data
     internal func toData(_ response: GotenbergResponse) async throws -> Data {
         // Collect response data
         logger.debug("Collecting response data from Gotenberg")
-        var responseData = Data()
-        for try await buffer in response.body {
-            responseData.append(Data(buffer.readableBytesView))
-        }
-
+        let responseData = try await Data(response.body.collect(upTo: .max).readableBytesView)
         logger.debug("Gotenberg request completed successfully, received \(responseData.count) bytes")
         return responseData
     }
@@ -244,6 +241,8 @@ public struct GotenbergClient: Sendable {
     /// Write a Gotenberg Response to a path
     /// - Parameters:
     ///   - response: The API response
+    ///   - path: The path to which the file should be written to
+    ///   - options: The writing options to use
     public func writeToFile(_ response: GotenbergResponse, at path: String, options: Data.WritingOptions = []) async throws {
         try await toData(response).write(
             to: URL(fileURLWithPath: path),

--- a/Sources/GotenbergKit/GotenbergClient.swift
+++ b/Sources/GotenbergKit/GotenbergClient.swift
@@ -4,8 +4,8 @@
 import AsyncHTTPClient
 import Logging
 import NIO
-import NIOHTTP1
 import NIOFoundationCompat
+import NIOHTTP1
 
 import struct Foundation.Data
 import struct Foundation.TimeInterval
@@ -200,7 +200,7 @@ public struct GotenbergClient: Sendable {
         switch response.status {
         case .ok, .noContent:
             return response
-        case .gatewayTimeout, .tooManyRequests, .serviceUnavailable, .requestTimeout, .internalServerError: // Retry-able status
+        case .gatewayTimeout, .tooManyRequests, .serviceUnavailable, .requestTimeout, .internalServerError:  // Retry-able status
             let retryCount = currentRetryCount + 1
             if retryCount < maxRetries {
                 let delayTime = min(exp2(Double(retryCount)), 30)
@@ -212,8 +212,8 @@ public struct GotenbergClient: Sendable {
             }
 
             throw GotenbergError.apiError(statusCode: response.status.code, message: "Exhausted retry attempts")
-        default: // Any non-success, non-retryable status
-            let errorData = try await response.body.collect(upTo: 1024 * 1024 * 8) // 8 MB of error response gotta be enough...
+        default:  // Any non-success, non-retryable status
+            let errorData = try await response.body.collect(upTo: 1024 * 1024 * 8)  // 8 MB of error response gotta be enough...
             let errorMessage = String(buffer: errorData)
             logger.error(
                 "Gotenberg API error with status",

--- a/Sources/GotenbergKit/LibreOffice/GotenberClient+LibreOffice.swift
+++ b/Sources/GotenbergKit/LibreOffice/GotenberClient+LibreOffice.swift
@@ -51,14 +51,12 @@ extension GotenbergClient {
 
         let values = options.formValues
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/libreoffice/convert",
             files: files,
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -84,19 +82,17 @@ extension GotenbergClient {
 
         // Convert to JSON
         let jsonData = try JSONEncoder().encode(urls)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
 
         var values = options.formValues
         values["downloadFrom"] = jsonString
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         return try await sendFormRequest(
             route: "/forms/libreoffice/convert",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 }

--- a/Sources/GotenbergKit/LibreOffice/LibreOfficeConversionOptions.swift
+++ b/Sources/GotenbergKit/LibreOffice/LibreOfficeConversionOptions.swift
@@ -252,13 +252,10 @@ public struct LibreOfficeConversionOptions {
         if let metadata = metadata {
             do {
                 let encoder = JSONEncoder()
-
                 encoder.dateEncodingStrategy = .formatted(Metadata.dateFormatter())
 
                 let data = try encoder.encode(metadata)
-                if let stringValue = String(data: data, encoding: .utf8) {
-                    values["metadata"] = stringValue
-                }
+                values["metadata"] = String(decoding: data, as: UTF8.self)
             } catch {
                 logger.error(
                     "Error serializing metadata",

--- a/Sources/GotenbergKit/PDFEngines/GotenbergClient+PDF.swift
+++ b/Sources/GotenbergKit/PDFEngines/GotenbergClient+PDF.swift
@@ -47,15 +47,13 @@ extension GotenbergClient {
             logger.debug("Document size: \(data.count) bytes")
         }
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         // Send request to Gotenberg
         return try await sendFormRequest(
             route: "/forms/pdfengines/merge",
             files: files,
             values: options.formValues,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -108,21 +106,19 @@ extension GotenbergClient {
 
         // Convert to JSON
         let jsonData = try JSONEncoder().encode(urls)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
 
         var values = options.formValues
         values["downloadFrom"] = jsonString
 
         logger.debug("downloadFrom JSON: \(jsonString)")
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/pdfengines/merge",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -147,21 +143,19 @@ extension GotenbergClient {
 
         // Convert to JSON
         let jsonData = try JSONEncoder().encode(urls)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
 
         var values = options.formValues
         values["downloadFrom"] = jsonString
 
         logger.debug("downloadFrom JSON: \(jsonString)")
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/pdfengines/convert",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -200,15 +194,13 @@ extension GotenbergClient {
             logger.debug("Document size: \(data.lazy.count) bytes")
         }
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         // Send request to Gotenberg
         return try await sendFormRequest(
             route: "/forms/pdfengines/convert",
             files: files,
             values: options.formValues,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -232,7 +224,7 @@ extension GotenbergClient {
             throw GotenbergError.noPDFsProvided
         }
 
-        logger.debug("Splitting \(documents.lazy.count) files PDFs from paths")
+        logger.debug("Splitting \(documents.count) files PDFs from paths")
 
         if options.splitUnify && options.splitMode != .pages {
             throw GotenbergError.invalidInput(message: "Unify option can only be used with mode: pages")
@@ -251,18 +243,16 @@ extension GotenbergClient {
                 )
             )
             logger.debug("Splitting file \(filename) using PDF engines route")
-            logger.debug("Document size: \(data.lazy.count) bytes")
+            logger.debug("Document size: \(data.count) bytes")
         }
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         // Send request to Gotenberg
         return try await sendFormRequest(
             route: "/forms/pdfengines/split",
             files: files,
             values: options.formValues,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -290,19 +280,17 @@ extension GotenbergClient {
 
         // Convert to JSON
         let jsonData = try JSONEncoder().encode(urls)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
 
         var values = options.formValues
         values["downloadFrom"] = jsonString
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         return try await sendFormRequest(
             route: "/forms/pdfengines/split",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -336,18 +324,16 @@ extension GotenbergClient {
                 )
             )
             logger.debug("Flattening file \(filename) using PDF engines route")
-            logger.debug("Document size: \(data.lazy.count) bytes")
+            logger.debug("Document size: \(data.count) bytes")
         }
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         // Send request to Gotenberg
         return try await sendFormRequest(
             route: "/forms/pdfengines/flatten",
             files: files,
             values: [:],
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -370,20 +356,18 @@ extension GotenbergClient {
 
         // Convert to JSON
         let jsonData = try JSONEncoder().encode(urls)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
 
         let values = [
             "downloadFrom": jsonString
         ]
 
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
-
         return try await sendFormRequest(
             route: "/forms/pdfengines/flatten",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -404,7 +388,7 @@ extension GotenbergClient {
             throw GotenbergError.noPDFsProvided
         }
 
-        logger.debug("Writting metadata for \(documents.lazy.count) PDFs from paths")
+        logger.debug("Writting metadata for \(documents.count) PDFs from paths")
 
         // Create request with PDF files
         var files: [FormFile] = []
@@ -419,39 +403,22 @@ extension GotenbergClient {
                 )
             )
             logger.debug("Writting metadata for file \(filename) using PDF engines route")
-            logger.debug("Document size: \(data.lazy.count) bytes")
+            logger.debug("Document size: \(data.count) bytes")
         }
 
         var values: [String: String] = [:]
 
-        do {
-            let encoder = JSONEncoder()
-
-            encoder.dateEncodingStrategy = .formatted(Metadata.dateFormatter())
-
-            let data = try encoder.encode(metadata)
-            if let stringValue = String(data: data, encoding: .utf8) {
-                values["metadata"] = stringValue
-            }
-        } catch {
-            logger.error(
-                "Error serializing metadata",
-                metadata: [
-                    "error": .string(error.localizedDescription)
-                ]
-            )
-            throw GotenbergError.invalidInput(message: "Error serializing metadata")
+        if !metadata.isEmpty {
+            values["metadata"] = try Metadata.serializeAsJSON(metadata, logger: logger)
         }
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         // Send request to Gotenberg
         return try await sendFormRequest(
             route: "/forms/pdfengines/metadata/write",
             files: files,
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -476,39 +443,22 @@ extension GotenbergClient {
 
         // Convert to JSON
         let jsonData = try JSONEncoder().encode(urls)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
 
         var values = [
             "downloadFrom": jsonString
         ]
 
-        do {
-            let encoder = JSONEncoder()
-
-            encoder.dateEncodingStrategy = .formatted(Metadata.dateFormatter())
-
-            let data = try encoder.encode(metadata)
-            if let stringValue = String(data: data, encoding: .utf8) {
-                values["metadata"] = stringValue
-            }
-        } catch {
-            logger.error(
-                "Error serializing metadata",
-                metadata: [
-                    "error": .string(error.localizedDescription)
-                ]
-            )
-            throw GotenbergError.invalidInput(message: "Error serializing metadata")
+        if !metadata.isEmpty {
+            values["metadata"] = try Metadata.serializeAsJSON(metadata, logger: logger)
         }
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         return try await sendFormRequest(
             route: "/forms/pdfengines/metadata/write",
             files: [],
             values: values,
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -527,16 +477,14 @@ extension GotenbergClient {
             throw GotenbergError.noURLsProvided
         }
 
-        logger.debug("Reading metadata for \(urls.lazy.count) PDFs from paths")
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
+        logger.debug("Reading metadata for \(urls.count) PDFs from paths")
 
         return try await sendFormRequest(
             route: "/forms/pdfengines/metadata/read",
             files: [],
             values: [:],
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 
@@ -570,18 +518,16 @@ extension GotenbergClient {
                 )
             )
             logger.debug("Reading metadata for file \(filename) using PDF engines route")
-            logger.debug("Document size: \(data.lazy.count) bytes")
+            logger.debug("Document size: \(data.count) bytes")
         }
-
-        var headers: [String: String] = clientHTTPHeaders
-        headers["Gotenberg-Wait-Timeout"] = "\(Int(waitTimeout))"
 
         // Send request to Gotenberg
         return try await sendFormRequest(
             route: "/forms/pdfengines/metadata/read",
             files: files,
             values: [:],
-            headers: headers
+            headers: clientHTTPHeaders,
+            timeoutSeconds: Int64(waitTimeout)
         )
     }
 }

--- a/Sources/GotenbergKit/PDFEngines/PDFEngineOptions.swift
+++ b/Sources/GotenbergKit/PDFEngines/PDFEngineOptions.swift
@@ -46,14 +46,10 @@ public struct PDFEngineOptions: Sendable {
         if let metadata = metadata {
             do {
                 let encoder = JSONEncoder()
-
                 encoder.dateEncodingStrategy = .formatted(Metadata.dateFormatter())
 
                 let data = try encoder.encode(metadata)
-
-                if let stringValue = String(data: data, encoding: .utf8) {
-                    values["metadata"] = stringValue
-                }
+                values["metadata"] = String(decoding: data, as: UTF8.self)
             } catch {
                 logger.error(
                     "Error serializing metadata",

--- a/Sources/GotenbergKit/PDFEngines/SplitPDFOptions.swift
+++ b/Sources/GotenbergKit/PDFEngines/SplitPDFOptions.swift
@@ -72,14 +72,10 @@ public struct SplitPDFOptions: Sendable {
         if let metadata = metadata {
             do {
                 let encoder = JSONEncoder()
-
                 encoder.dateEncodingStrategy = .formatted(Metadata.dateFormatter())
 
                 let data = try encoder.encode(metadata)
-
-                if let stringValue = String(data: data, encoding: .utf8) {
-                    values["metadata"] = stringValue
-                }
+                values["metadata"] = String(decoding: data, as: UTF8.self)
             } catch {
                 logger.error(
                     "Error serializing metadata",

--- a/Tests/GotenbergKitTests/ConvertWithLibreOfficeTests.swift
+++ b/Tests/GotenbergKitTests/ConvertWithLibreOfficeTests.swift
@@ -52,7 +52,7 @@ struct ConvertWithLibreOfficeTests {
     @Test
     func convertOpenDocumentToPDF() async throws {
         logger.info("Converting Open Document to PDF")
-        let resourceURL = Bundle.module.url(forResource: "sample", withExtension: "odt", subdirectory: "Resources/documents")!
+        let resourceURL = try #require(Bundle.module.url(forResource: "sample", withExtension: "odt", subdirectory: "Resources/documents"))
 
         let document = try Data(contentsOf: resourceURL)
 
@@ -73,9 +73,9 @@ struct ConvertWithLibreOfficeTests {
     func convertAndMergeDocuments() async throws {
         logger.info("Converting and merging multiple documents")
 
-        let odt = Bundle.module.url(forResource: "sample", withExtension: "odt", subdirectory: "Resources/documents")!
+        let odt = try #require(Bundle.module.url(forResource: "sample", withExtension: "odt", subdirectory: "Resources/documents"))
 
-        let pdf = Bundle.module.url(forResource: "simple", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let pdf = try #require(Bundle.module.url(forResource: "simple", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         let csv = Bundle.module.url(
             forResource: "MTA_Subway_Major_Incidents__Beginning_2020",

--- a/Tests/GotenbergKitTests/GotenbergKitTests.swift
+++ b/Tests/GotenbergKitTests/GotenbergKitTests.swift
@@ -125,7 +125,10 @@ struct GokenbergKitTests {
         let pdfWithAssets = try await client.convert(
             html: htmlData,
             header: Data("<div style='text-align: center; font-size: 10px;'>Generated with Gotenberg</div>".utf8),
-            footer: Data("<div style='text-align: center; font-size: 10px;'>Page <span class='pageNumber'></span> of <span class='totalPages'></span></div>".utf8),
+            footer: Data(
+                "<div style='text-align: center; font-size: 10px;'>Page <span class='pageNumber'></span> of <span class='totalPages'></span></div>"
+                    .utf8
+            ),
             assets: assets,
             options: ChromiumOptions(
                 paperWidth: 8.5,

--- a/Tests/GotenbergKitTests/GotenbergKitTests.swift
+++ b/Tests/GotenbergKitTests/GotenbergKitTests.swift
@@ -50,7 +50,7 @@ struct GokenbergKitTests {
             """
 
         let result = try await client.convert(
-            html: htmlContent.data(using: .utf8)!
+            html: Data(htmlContent.utf8)
         )
         #expect(result.status.code == 200)
         try await client.writeToFile(result, at: "\(baseOutputPath)/simple.pdf")
@@ -111,28 +111,21 @@ struct GokenbergKitTests {
             """
 
         // Load image data from a file
-        let logoData = try await HTTPClient.shared.get(url: "https://logolab.app/assets/logo.png").get()
-
-        guard let logoData = logoData.body else {
-            #expect(Bool(false))
-            return
-        }
+        let logoData = try await #require(HTTPClient.shared.get(url: "https://logolab.app/assets/logo.png").get().body)
 
         // Prepare assets
         let assets: [String: Data] = [
-            "styles.css": cssContent.data(using: .utf8)!,
-            "script.js": jsContent.data(using: .utf8)!,
+            "styles.css": Data(cssContent.utf8),
+            "script.js": Data(jsContent.utf8),
             "logo.png": Data(buffer: logoData),
         ]
 
-        let htmlData = htmlWithAssets.data(using: .utf8)!
+        let htmlData = Data(htmlWithAssets.utf8)
 
         let pdfWithAssets = try await client.convert(
             html: htmlData,
-            header: "<div style='text-align: center; font-size: 10px;'>Generated with Gotenberg</div>".data(using: .utf8)!,
-            footer:
-                "<div style='text-align: center; font-size: 10px;'>Page <span class='pageNumber'></span> of <span class='totalPages'></span></div>"
-                .data(using: .utf8)!,
+            header: Data("<div style='text-align: center; font-size: 10px;'>Generated with Gotenberg</div>".utf8),
+            footer: Data("<div style='text-align: center; font-size: 10px;'>Page <span class='pageNumber'></span> of <span class='totalPages'></span></div>".utf8),
             assets: assets,
             options: ChromiumOptions(
                 paperWidth: 8.5,
@@ -153,7 +146,7 @@ struct GokenbergKitTests {
     func urlToPDF() async throws {
 
         let pdfData = try await client.convert(
-            url: URL(string: "https://developer.apple.com/swift")!,
+            url: #require(URL(string: "https://developer.apple.com/swift")),
             options: ChromiumOptions(
                 paperWidth: 11.0,
                 paperHeight: 8.5,  // Landscape size
@@ -262,17 +255,17 @@ struct GokenbergKitTests {
             """
 
         // Load logo image
-        let url = Bundle.module.url(forResource: "test-logo", withExtension: "png", subdirectory: "Resources/images")!
+        let url = try #require(Bundle.module.url(forResource: "test-logo", withExtension: "png", subdirectory: "Resources/images"))
         let logoData = try Data(contentsOf: url)
 
         // Prepare files
         let markdownFiles = [
-            "index.html": htmlContent.data(using: .utf8)!,
-            "document.md": markdownContent.data(using: .utf8)!,
+            "index.html": Data(htmlContent.utf8),
+            "document.md": Data(markdownContent.utf8),
         ]
 
         let assets = [
-            "custom.css": customCSS.data(using: .utf8)!,
+            "custom.css": Data(customCSS.utf8),
             "logo.png": logoData,
         ]
 
@@ -296,11 +289,11 @@ struct GokenbergKitTests {
 
     @Test
     func batchProcessingURLToPDF() async throws {
-        let urls = [
+        let urls = try [
             "https://github.com",
             "https://developer.apple.com",
             "https://swift.org",
-        ].map { URL(string: $0)! }
+        ].map { try #require(URL(string: $0)) }
 
         typealias Response = [URL: GotenbergClient.GotenbergResponse]
 
@@ -333,11 +326,11 @@ struct GokenbergKitTests {
 
     @Test
     func batchProcessingURLToPNG() async throws {
-        let urls = [
+        let urls = try [
             "https://github.com",
             "https://developer.apple.com",
             "https://swift.org",
-        ].map { URL(string: $0)! }
+        ].map { try #require(URL(string: $0)) }
 
         let result = try await client.capture(
             urls: urls,
@@ -362,5 +355,24 @@ struct GokenbergKitTests {
 
         let contentType = "application/pdf"
         #expect(GotenbergClient.isFileSupported(contentType) == true)
+    }
+
+    @Test
+    func testVersion() async throws {
+        let version = try await client.version()
+        #expect(version.isEmpty == false)
+    }
+
+    @Test
+    func testHealth() async throws {
+        let health = try await client.health()
+        #expect(health.status == .up)
+        let details = try #require(health.details)
+        let chromium = try #require(details.chromium)
+        #expect(chromium.status == .up)
+        #expect(chromium.timestamp <= .now)
+        let libreOffice = try #require(details.libreOffice)
+        #expect(libreOffice.status == .up)
+        #expect(libreOffice.timestamp <= .now)
     }
 }

--- a/Tests/GotenbergKitTests/PDFEnginesTests.swift
+++ b/Tests/GotenbergKitTests/PDFEnginesTests.swift
@@ -44,10 +44,10 @@ struct PDFEnginesTests {
 
     //    @Test
     //    func mergePDFsFromURL() async throws {
-    //        let pdfURLs: [URL] = [
+    //        let pdfURLs: [URL] = try [
     //            "\(serverURL)/documents/page_1.pdf",
     //            "\(serverURL)/documents/page_2.pdf",
-    //        ].map { URL(string: $0)! }
+    //        ].map { try #require(URL(string: $0)) }
     //
     //        logger.info("Starting to merge \(pdfURLs.count) PDFs")
     //
@@ -72,9 +72,9 @@ struct PDFEnginesTests {
 
     @Test
     func mergePDFsFromPath() async throws {
-        let pdf1 = Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let pdf1 = try #require(Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents"))
 
-        let pdf2 = Bundle.module.url(forResource: "page_2", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let pdf2 = try #require(Bundle.module.url(forResource: "page_2", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         let document1 = try Data(contentsOf: pdf1)
         let document2 = try Data(contentsOf: pdf2)
@@ -106,9 +106,9 @@ struct PDFEnginesTests {
 
     @Test
     func convertWithPDFEngines() async throws {
-        let doc1 = Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let doc1 = try #require(Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents"))
 
-        let doc2 = Bundle.module.url(forResource: "page_2", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let doc2 = try #require(Bundle.module.url(forResource: "page_2", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         let document1 = try Data(contentsOf: doc1)
         let document2 = try Data(contentsOf: doc2)
@@ -145,7 +145,7 @@ struct PDFEnginesTests {
 
     @Test
     func splitPDFs() async throws {
-        let document = Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document = try #require(Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         logger.info("Starting to split file to mutiple PDFs")
 
@@ -172,9 +172,9 @@ struct PDFEnginesTests {
 
     @Test
     func flattenPDFs() async throws {
-        let document = Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document = try #require(Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents"))
 
-        let document1 = Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document1 = try #require(Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         logger.info("Starting to flatten files")
 
@@ -202,9 +202,9 @@ struct PDFEnginesTests {
 
     @Test
     func writePDFsMetadata() async throws {
-        let document = Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document = try #require(Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents"))
 
-        let document1 = Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document1 = try #require(Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         logger.info("Starting to write metadata to files")
 
@@ -236,9 +236,9 @@ struct PDFEnginesTests {
 
     @Test
     func readPDFsMetadata() async throws {
-        let document = Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document = try #require(Bundle.module.url(forResource: "pages_3", withExtension: "pdf", subdirectory: "Resources/documents"))
 
-        let document1 = Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents")!
+        let document1 = try #require(Bundle.module.url(forResource: "page_1", withExtension: "pdf", subdirectory: "Resources/documents"))
 
         logger.info("Starting to write metadata to files")
 


### PR DESCRIPTION
Mainly, this adds support for the meta endpoints `/health` and `/version`.

While doing so, I also made the following other improvements:

- Reduce number of implicitly and force unwrapped optionals by using non-optional conversion between `String` <-> `Data` as well as `#require` in tests.
- Reduce code duplication by centralizing metadata serialization
  - There are more opportunities for improvements here, but that was a rather low hanging fruit
- Performance improvements:
  - Retried requests are now re-used instead of being recreated from scratch
  - Reading response bodies now uses optimized APIs of ByteBuffer etc.
  - TimeOuts are no longer serialized into headers only to be parsed again - they are now passed directly to the execution methods instead