### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-validate
   cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   validate:


### PR DESCRIPTION
Potential fix for [https://github.com/thoven87/gotenberg-kit/security/code-scanning/3](https://github.com/thoven87/gotenberg-kit/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow performs a validation task and does not appear to require write access, the permissions can be limited to `contents: read`. This ensures that the workflow has only the minimal access required to complete its task.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs unless overridden. This change will restrict the `GITHUB_TOKEN` permissions and adhere to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
